### PR TITLE
GitHub Community Files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+Please review Statamic's [Code of Conduct](https://statamic.dev/code-of-conduct) as it applies to this addon.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing
+✨ Before we get started, thank you for taking the time to contribute! ✨
+
+This is the Contributing Guide for all addons in the [Statamic Rad Pack](https://github.com/statamic-rad-pack). We welcome your feedback, proposed changes, and updates to these guidelines. We will always welcome thoughtful issues and consider pull requests.
+
+## What You Should Know Before Contributing
+
+### How to Get Support
+All of the addons in the Rad Pack are maintained by contributors in their free time. As such, there's no special "support system" for issues you're running into.
+
+If you need help, you can ask the community via GitHub Discussions or on the [`#rad-pack-support`](https://discord.gg/ytqCaQUxTv) channel on Discord.
+
+## How You Can Contribute
+
+### Bug Reports
+First things first. If the bug is security related refer to our [security disclosures](./SECURITY.md) procedures instead of opening an issue.
+
+Next, please search through the open issues to see if it has already been opened.
+
+If you do find a similar issue, upvote it by adding a 👍 reaction. Only leave a comment if you have relevant information to add.
+
+If no one has filed the issue yet, feel free to submit a new one. Please include a clear description of the issue, follow along with the issue template, and provide and as much relevant information as possible. Code examples demonstrating the issue are the best way to ensure a timely solution to the issue.
+
+### Feature Requests
+If you have a feature request, please open a GitHub Discussion in the relevant category.
+
+### Security Disclosures
+If you discover a security vulnerability, please review our [Security Policy](./SECURITY.md), then report the issue directly to the Statamic Core Team from [statamic.com/support](https://statamic.com/support). We will review and respond privately via email.
+
+### Documentation Edits
+Usually, you'll find the documentation for an addon inside the `docs` directory, inside a `DOCUMENTATION.md` file or the addon's `README.md`.
+
+You can submit improvements or corrections to them via a pull request.
+
+### Compiled Assets
+If you are submitting a change that will affect a compiled file, such as most of the files in `resources/css` or `resources/js`, **do not** commit the compiled files.
+
+Due to their large size, they cannot realistically be reviewed by maintainers. This could be exploited as a way to inject malicious code into Statamic. In order to defensively prevent this, all compiled files will be generated upon release by GitHub Actions.
+
+### Pull Requests
+Pull requests should clearly describe the problem and solution. Include the relevant issue number if there is one. If the pull request fixes a bug, it should include a new test case that demonstrates the issue, if possible.
+
+Creating a pull request that introduces a new feature or changes current behavior? Please include updates to any relevant documentation in your PR.
+
+PR titles should include the major version number they're targeted at — e.g. [4.x] or [3.x].
+
+<br>
+Thank you! Stay rad. If you're not already rad, tell us and we will make it so.
+
+:sparkles:

--- a/.github/DISCUSSION_TEMPLATE/help.yml
+++ b/.github/DISCUSSION_TEMPLATE/help.yml
@@ -1,0 +1,13 @@
+body:
+- type: textarea
+  attributes:
+    label: Description
+    placeholder: "What do you need help with? Please be as detailed as possible."
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Environment
+    description: Copy & paste the output of `php please support:details` here.
+  validations:
+    required: true

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: statamic

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,28 @@
+name: '🐛 Bug Report'
+description: "Found a bug or something that's not quite working like it should? Open an issue."
+labels: [bug]
+body:
+- type: markdown
+  attributes:
+    value: Thanks for taking the time to submit a bug report! Please fill out the fields with as much detail as possible, so we can get to the bottom of the issue as quickly as possible.
+- type: textarea
+  attributes:
+    label: Description
+    placeholder: "What's happening? What are you expecting to happen?"
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    placeholder: |
+        1. Do this thing...
+        2. Then do that thing...
+        3. And finally, do something else...
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Environment
+    description: Copy & paste the output of `php please support:details` here.
+  validations:
+    required: true

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,45 @@
+If you discover a security vulnerability in of the addons in the Statamic Rad Pack, please review the following guidelines before submitting a report. We take security very seriously, and we do our best to resolve security issues as quickly as possible.
+
+## Guidelines
+While working to identify potential security vulnerabilities, we ask that you:
+
+- **Privately** share any issues that you discover with us via statamic.com/support as soon as possible.
+- Give us a reasonable amount of time to address any reported issues before publicizing them.
+- Only report issues that are in scope.
+- Provide a quality report with precise explanations and concrete attack scenarios.
+
+## Scope
+We are only interested in vulnerabilities that affect the addons themselves, tested against **your own local installation** of the software, running the latest version. Do **not** test against any Statamic sites that you don't own, including [statamic.com](https:/statamic.com) or [statamic.dev](https://statamic.dev).
+
+### Potentially Qualifying Vulnerabilities
+
+- [Cross-Site Scripting (XSS)](https://en.wikipedia.org/wiki/Cross-site_scripting)
+- [Cross-Site Request Forgery (CSRF)](https://en.wikipedia.org/wiki/Cross-site_request_forgery)
+- [Arbitrary Code Execution](https://en.wikipedia.org/wiki/Arbitrary_code_execution)
+- [Privilege Escalation](https://en.wikipedia.org/wiki/Privilege_escalation)
+- [SQL Injection](https://en.wikipedia.org/wiki/SQL_injection)
+- [Session Hijacking](https://en.wikipedia.org/wiki/Session_hijacking)
+
+### Non-Qualifying Vulnerabilities
+
+- XSS vectors or bugs that rely on an unlikely user interaction (i.e. a privileged user attacking themselves or their own site)
+- Reports from automated tools or scanners
+- Theoretical attacks without actual proof of exploitability
+- Attacks that can be guarded against by following our security recommendations.
+- Server configuration issues outside of Statamic’s control
+- [Denial of Service](https://en.wikipedia.org/wiki/Denial-of-service_attack) attacks
+- [Brute force attacks](https://en.wikipedia.org/wiki/Brute-force_attack) (e.g. on password or email address)
+- Username or email address enumeration
+- Social engineering of Statamic staff or users of Statamic installations
+- Physical attacks against Statamic installations
+- Attacks involving physical access to a user’s device, or involving a device or network that is already seriously compromised (e.g. [man-in-the-middle attacks](https://en.wikipedia.org/wiki/Man-in-the-middle_attack))
+- Attacks that are the result of Statamic Core should be reported to the Statamic Core Team
+- Disclosure of tools or libraries used by Statamic and/or their versions
+- Issues that are the result of a user doing something silly (like sharing their password publicly)
+- Missing security headers which do not lead directly to a vulnerability via proof of concept
+- Vulnerabilities affecting users of outdated/unsupported browsers or platforms
+- Vulnerabilities affecting outdated versions of Statamic
+- Any behavior that is clearly documented.
+- Issues discovered while scanning a site you don’t own without permission
+- Missing CSRF tokens on forms (unless you have a proof of concept, many forms either don't need CSRF or are mitigated in other ways) and "logout" CSRF attacks
+- [Open redirects](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html)


### PR DESCRIPTION
This pull request implements [default community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file). 

This allows us to share the same code of conduct, issue templates, contributing guide between all addons in The Rad Pack.